### PR TITLE
feat: dataspex.core/inspect now returns the inspected thing rather than nil

### DIFF
--- a/src/dataspex/core.clj
+++ b/src/dataspex/core.clj
@@ -53,7 +53,7 @@
   (inspector/inspect store label x opt)
   (when (and (nil? @server) (not (false? (:start-server? opt))))
     (start-server!))
-  nil)
+  x)
 
 (defn ^:export uninspect [label]
   (inspector/uninspect store label)

--- a/src/dataspex/core.cljs
+++ b/src/dataspex/core.cljs
@@ -27,7 +27,8 @@
   {:arglists '[[label x]
                [label x {:keys [track-changes? history-limit max-height]}]]}
   [label x & [opt]]
-  (inspector/inspect store label x opt))
+  (inspector/inspect store label x opt)
+  x)
 
 (defn ^:export uninspect [label]
   (inspector/uninspect store label)


### PR DESCRIPTION
For transparent use, a la (tap> ...), as discussed here:
https://clojurians.slack.com/archives/C06JZ4X334N/p1746789131810679?thread_ts=1746713715.310389&cid=C06JZ4X334N

I've kept the intervention as simple/shallow as possible. It may be appropriate to modify core.inspector/inspect along similar lines, but that has a lot more internal use and I don't know what I'm doing :)

There are test failures on my machine, but I suspect they're unrelated to this change and have something to do with my timezone (expectations for three cases out by an hour). One sample below:

```
FAIL in dataspex.actions-test/inspect-revision-test (actions_test.cljc:37)
Inspects revision of other value
Expected:
  [[:effect/inspect "Store@18:19:58" nil {:my "Data"} {:auditable? false}]]
Actual:
  [[:effect/inspect -"Store@18:19:58" +"Store@17:19:58" nil {:my "Data"} {:auditable? false}]]
```