### PR TITLE
`[inspector.css]` Horizontal scrollbar only when necessary

### DIFF
--- a/resources/public/dataspex/inspector.css
+++ b/resources/public/dataspex/inspector.css
@@ -182,7 +182,7 @@ body, pre {
 }
 
 .scroll-x {
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 /* Color schemes */


### PR DESCRIPTION
This change removes the unsightly scrollbar, only having it appear when necessary.