### PR TITLE
Pass :port to start-server!

### DIFF
--- a/src/dataspex/core.clj
+++ b/src/dataspex/core.clj
@@ -53,7 +53,7 @@
     (swap! store assoc :dataspex/host-str (get-host-str)))
   (inspector/inspect store label x opt)
   (when (and (nil? @server) (not (false? (:start-server? opt))))
-    (start-server!))
+    (start-server! {:port (:server-port opt)}))
   x)
 
 (defn ^:export uninspect [label]


### PR DESCRIPTION
Allows users to specify the server port, which is necessary if running dataspex in multiple processes at the same time.