### PR TITLE
fix: Embed revision identifier for firefox extension. (fixes #14)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ node_modules:
 
 browser-extension/extension.js: node_modules shadow-cljs.edn $(wildcard src/dataspex/*.clj*)
 	npx shadow-cljs release browser-extension
+  $(info Building browser extension at version $(VERSION))
 
 browser-extension/chrome/manifest.json: pom.xml
 	sed 's/VERSION/$(VERSION)/' browser-extension/chrome/manifest.tpl.json > browser-extension/chrome/manifest.json
@@ -19,7 +20,7 @@ chrome-extension: browser-extension/extension.js browser-extension/chrome/manife
 browser-extension/firefox/manifest.json:
 	sed 's/VERSION/$(VERSION)/' browser-extension/firefox/manifest.tpl.json > browser-extension/firefox/manifest.json
 
-firefox-extension: browser-extension/extension.js
+firefox-extension: browser-extension/extension.js browser-extension/firefox/manifest.json
 	cp resources/public/dataspex/inspector.css browser-extension/firefox/inspector.css
 	cp browser-extension/extension.js browser-extension/firefox/extension.js
 	cp browser-extension/content-script.js browser-extension/firefox/content-script.js
@@ -30,7 +31,7 @@ resources/public/dataspex/inspector.js:
 	npx shadow-cljs release remote-inspector
 
 clean:
-	rm -fr target resources/public/app dev-resources/public/dataspex resources/public/dataspex/cljs-runtime resources/public/dataspex/inspector.js resources/public/dataspex/manifest.edn browser-extension/manifest.edn browser-extension/inspector.css browser-extension/extension.js dev-resources/public/portfolio dataspex.jar
+	rm -fr target resources/public/app dev-resources/public/dataspex resources/public/dataspex/cljs-runtime resources/public/dataspex/inspector.js resources/public/dataspex/manifest.edn browser-extension/manifest.edn browser-extension/inspector.css browser-extension/extension.js browser-extension/chrome/manifest.json browser-extension/firefox/manfiest.json browserdev-resources/public/portfolio dataspex.jar
 
 dataspex.jar: resources/public/dataspex/inspector.js
 	clojure -M:jar

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ features, including:
 
 And much more.
 
+## Build dependencies
+
+The Makefile build tasks for the Chrome and Firefox browser extensions rely on the `xmllint` binary
+to embed the current version string. This is typically included with an installation of `libxml2` or
+`libxml2-utils` on Linux distributions (`libxml2` is installed by default on MacOS).
+
 ## Chrome extension
 
 To build the Chrome extension:


### PR DESCRIPTION
libxml2 isn't necessarily installed by default on Linux distros. Added a note to README calling out the dependency.

Updated firefox extension build task to use the (existing) task to update manifest.json with extracted version.

Updated the clean task to delete existing manifest.json

Update the Makefile to output the extracted version to the console... should maybe make it more obvious when libxml2 not installed....