### PR TITLE
Add missing quote in dataspex code example

### DIFF
--- a/src/dataspex/render_client.cljs
+++ b/src/dataspex/render_client.cljs
@@ -97,7 +97,7 @@
      "Well, it ain't much to look at - yet. "
      "You can fix that by telling Dataspex to inspect something:"]
     (hiccup/render-source
-     '(require [dataspex.core :as dataspex])
+     '(require '[dataspex.core :as dataspex])
      {})
     (hiccup/render-source
      '(dataspex/inspect "App state" my-data)


### PR DESCRIPTION
This adds the missing quote in the following screen:

<img width="469" height="283" alt="Screenshot 2026-02-06 at 15 25 41" src="https://github.com/user-attachments/assets/a52a8847-b60e-4c0d-a6cf-5a3c2b730434" />

```clojure
(require [dataspex.core :as dataspex])
```
becomes
```clojure
(require '[dataspex.core :as dataspex])
```