### PR TITLE
firefox port per tab

### DIFF
--- a/browser-extension/firefox/background.js
+++ b/browser-extension/firefox/background.js
@@ -1,17 +1,21 @@
-let panelPort = null;
+const panelPortsByTabId = new Map();
+const panelPortPrefix = "dataspex-panel-"
 
 chrome.runtime.onConnect.addListener((port) => {
-  if (port.name === "dataspex-panel") {
-    panelPort = port;
+  if (port.name.startsWith(panelPortPrefix)) {
+    const tabId = parseInt(port.name.slice(panelPortPrefix.length));
+    tabId && panelPortsByTabId.set(tabId, port);
 
     port.onDisconnect.addListener(() => {
-      panelPort = null;
+      tabId && panelPortsByTabId.delete(tabId);
     });
   }
 });
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  if (message.from === "dataspex-library" && panelPort) {
-    panelPort.postMessage(message);
+  if (message.from === "dataspex-library") {
+    const tabId = sender.tab?.id;
+    const port = panelPortsByTabId.get(tabId);
+    port?.postMessage(message);
   }
 });

--- a/src/dataspex/browser_extension_client.cljs
+++ b/src/dataspex/browser_extension_client.cljs
@@ -33,7 +33,7 @@
 (defn subscribe-to-messages [render on-message]
   (when (and js/chrome js/chrome.runtime)
     (if firefox?
-      (-> (js/chrome.runtime.connect #js {:name "dataspex-panel"})
+      (-> (js/chrome.runtime.connect #js {:name (str "dataspex-panel-" js/browser.devtools.inspectedWindow.tabId)})
           .-onMessage
           (.addListener
            (fn [^js message]


### PR DESCRIPTION
I noticed an issue in which opening dataspex in multiple tabs would cause the dev panel to freeze in all but the most recently opened (as mentioned in https://github.com/cjohansen/dataspex/pull/29). On further investigation (lots of logging), I found that all render messages (from all tabs) were going to that most recent panel.

The cause was the `panelPort` being overwritten by each new panel as the background script is global. To preserve ports for multiple tabs I've added a map of tab id -> port. The tab id is communicated to the background script from the dev panel by appending it to the port name. Conveniently, messages from the content script already have the tab id in the sender object :)